### PR TITLE
Let There Be CAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Convert CMake flags to compiler flags
 ###############################################################################
 if(EVT_CORE_LOG_ENABLE)
-    message(please)
     add_compile_definitions(EVT_CORE_LOG_ENABLE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${PROJECT_NAME} STATIC)
 
 # Add sources
 target_sources(${PROJECT_NAME} PRIVATE
+        src/TMS/TMS.cpp
         src/TMS/dev/HeatPump.cpp
         src/TMS/dev/RadiatorFan.cpp
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
 ###############################################################################
+# Convert CMake flags to compiler flags
+###############################################################################
+if(EVT_CORE_LOG_ENABLE)
+    message(please)
+    add_compile_definitions(EVT_CORE_LOG_ENABLE)
+endif()
+
+###############################################################################
 # Top level CMakeList for building the TMS source code
 ###############################################################################
 cmake_minimum_required(VERSION 3.15)

--- a/include/TMS/TMS.hpp
+++ b/include/TMS/TMS.hpp
@@ -1,0 +1,153 @@
+#ifndef TMS_INCLUDE_TMS_TMS_HPP
+#define TMS_INCLUDE_TMS_TMS_HPP
+
+#include <Canopen/co_core.h>
+
+namespace TMS {
+
+class TMS {
+public:
+    TMS() = default;
+
+    /**
+     * The node ID used to identify the device on the CAN network.
+     */
+    static constexpr uint8_t NODE_ID = 0x02;
+
+    /**
+     * Get a pointer to the start of the CANopen object dictionary.
+     *
+     * @return Pointer to the start of the CANopen object dictionary.
+     */
+    CO_OBJ_T* getObjectDictionary();
+
+    /**
+     * Get the number of elements in the object dictionary.
+     *
+     * @return The number of elements in the object dictionary
+     */
+    uint16_t getObjectDictionarySize();
+
+private:
+    /**
+     * This sample data will be exposed over CAN through the object
+     * dictionary. The address of the variable will be included in the
+     * object dictionary and can be updated via SDO via a CANopen client.
+     * This device will then broadcast the value via a triggered PDO.
+     */
+    uint8_t sampleData;
+
+    /**
+     * Have to know the size of the object dictionary for initialization
+     * process.
+     */
+    static constexpr uint16_t OBJECT_DICTIONARY_SIZE = 16;
+
+    CO_OBJ_T objectDictionary[OBJECT_DICTIONARY_SIZE + 1] = {
+        // Sync ID, defaults to 0x80
+        {
+            .Key = CO_KEY(0x1005, 0, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0x80,
+        },
+        // Information about the hardware, hard coded sample values for now
+        // 1: Vendor ID
+        // 2: Product Code
+        // 3: Revision Number
+        // 4: Serial Number
+        {
+            .Key = CO_KEY(0x1018, 1, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0x10},
+        {
+            .Key = CO_KEY(0x1018, 2, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0x11,
+        },
+        {
+            .Key = CO_KEY(0x1018, 3, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0x12,
+        },
+        {
+            .Key = CO_KEY(0x1018, 4, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0x13,
+        },
+
+        // SDO CAN message IDS.
+        // 1: Client -> Server ID, default is 0x600 + NODE_ID
+        // 2: Server -> Client ID, default is 0x580 + NODE_ID
+        {
+            .Key = CO_KEY(0x1200, 1, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0x600 + NODE_ID,
+        },
+        {
+            .Key = CO_KEY(0x1200, 2, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0x580 + NODE_ID,
+        },
+
+        // TPDO0 settings
+        // 0: The TPDO number, default 0
+        // 1: The COB-ID used by TPDO0, provided as a function of the TPDO number
+        // 2: How the TPO is triggered, default to manual triggering
+        // 3: Inhibit time, defaults to 0
+        // 5: Timer trigger time in 1ms units, 0 will disable the timer based triggering
+        {
+            .Key = CO_KEY(0x1800, 0, CO_UNSIGNED8 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0,
+        },
+        {
+            .Key = CO_KEY(0x1800, 1, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) CO_COBID_TPDO_DEFAULT(0),
+        },
+        {
+            .Key = CO_KEY(0x1800, 2, CO_UNSIGNED8 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0xFE,
+        },
+        {
+            .Key = CO_KEY(0x1800, 3, CO_UNSIGNED16 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 0,
+        },
+        {
+            .Key = CO_KEY(0x1800, 5, CO_UNSIGNED16 | CO_OBJ_D__R_),
+            .Type = CO_TEVENT,
+            .Data = (uintptr_t) 2000,
+        },
+
+        // TPDO0 mapping, determins the PDO messages to send when TPDO1 is triggered
+        // 0: The number of PDO message associated with the TPDO
+        // 1: Link to the first PDO message
+        // n: Link to the nth PDO message
+        {
+            .Key = CO_KEY(0x1A00, 0, CO_UNSIGNED8 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = (uintptr_t) 1},
+        {
+            .Key = CO_KEY(0x1A00, 1, CO_UNSIGNED32 | CO_OBJ_D__R_),
+            .Type = nullptr,
+            .Data = CO_LINK(0x2100, 0, 8)// Link to sample data position in dictionary
+        },
+
+        // User defined data, this will be where we put elements that can be
+        // accessed via SDO and depending on configuration PDO
+        {
+            .Key = CO_KEY(0x2100, 0, CO_UNSIGNED8 | CO_OBJ___PRW),
+            .Type = nullptr,
+            .Data = (uintptr_t) &sampleData,
+        },
+
+        // End of dictionary marker
+        CO_OBJ_DIR_ENDMARK,
+    };
+};
+
+}// namespace TMS
+
+#endif//TMS_INCLUDE_TMS_TMS_HPP

--- a/src/TMS/TMS.cpp
+++ b/src/TMS/TMS.cpp
@@ -1,0 +1,11 @@
+#include <TMS/TMS.hpp>
+
+namespace TMS {
+
+CO_OBJ_T* TMS::getObjectDictionary() {
+    return &objectDictionary[0];
+}
+uint16_t TMS::getObjectDictionarySize() {
+    return OBJECT_DICTIONARY_SIZE;
+}
+}

--- a/src/TMS/TMS.cpp
+++ b/src/TMS/TMS.cpp
@@ -8,4 +8,4 @@ CO_OBJ_T* TMS::getObjectDictionary() {
 uint16_t TMS::getObjectDictionarySize() {
     return OBJECT_DICTIONARY_SIZE;
 }
-}
+}// namespace TMS

--- a/targets/TMS/main.cpp
+++ b/targets/TMS/main.cpp
@@ -3,6 +3,7 @@
  * basic echo functionality where the uart will write back whatever the user
  * enters.
  */
+#include <EVT/dev/platform/f3xx/f302x8/Timerf302x8.hpp>
 #include <EVT/io/CANopen.hpp>
 #include <EVT/io/UART.hpp>
 #include <EVT/io/manager.hpp>
@@ -10,7 +11,6 @@
 #include <EVT/io/types/CANMessage.hpp>
 #include <EVT/utils/log.hpp>
 #include <EVT/utils/types/FixedQueue.hpp>
-#include <EVT/dev/platform/f3xx/f302x8/Timerf302x8.hpp>
 
 #include <TMS/TMS.hpp>
 
@@ -19,10 +19,8 @@ namespace DEV = EVT::core::DEV;
 namespace time = EVT::core::time;
 namespace log = EVT::core::log;
 
-
 // Global CAN Node reference
 CO_NODE canNode;
-
 
 void handleNMT(IO::CANMessage& message) {
     uint8_t* payload = message.getPayload();
@@ -50,7 +48,7 @@ void handleNMT(IO::CANMessage& message) {
  */
 void canInterruptHandler(IO::CANMessage& message, void* priv) {
     // Handle NMT messages
-    if(message.getId() == 0) {
+    if (message.getId() == 0) {
         handleNMT(message);
         return;
     }
@@ -159,7 +157,7 @@ int main() {
         // Handle executing timer events that have elapsed
         COTmrProcess(&canNode.Tmr);
 
-        switch(CONmtGetMode(&canNode.Nmt)) {
+        switch (CONmtGetMode(&canNode.Nmt)) {
         // Auxiliary Mode
         case CO_PREOP:
             break;

--- a/targets/TMS/main.cpp
+++ b/targets/TMS/main.cpp
@@ -3,26 +3,134 @@
  * basic echo functionality where the uart will write back whatever the user
  * enters.
  */
-#include <EVT/io/UART.hpp>
 #include <EVT/io/manager.hpp>
 #include <EVT/io/pin.hpp>
+#include <EVT/io/UART.hpp>
+#include <EVT/io/types/CANMessage.hpp>
+#include <EVT/utils/types/FixedQueue.hpp>
+#include <EVT/io/CANopen.hpp>
+#include <EVT/dev/platform/f3xx/f302x8/Timerf302x8.hpp>
+#include <EVT/utils/log.hpp>
+
+#include <TMS/TMS.hpp>
 
 namespace IO = EVT::core::IO;
+namespace DEV = EVT::core::DEV;
+namespace time = EVT::core::time;
+namespace log = EVT::core::log;
+
+/**
+ * Interrupt handler for incoming CAN messages.
+ *
+ * @param priv[in] The private data (FixedQueue<CANOPEN_QUEUE_SIZE, CANMessage>)
+ */
+void canInterruptHandler(IO::CANMessage& message, void* priv) {
+    EVT::core::types::FixedQueue<CANOPEN_QUEUE_SIZE, IO::CANMessage>* queue =
+        (EVT::core::types::FixedQueue<CANOPEN_QUEUE_SIZE, IO::CANMessage>*)priv;
+    if (queue == nullptr)
+        return;
+    if (!message.isCANExtended())
+        queue->append(message);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// CANopen specific Callbacks. Need to be defined in some location
+///////////////////////////////////////////////////////////////////////////////
+extern "C" void CONodeFatalError(void) {
+    log::LOGGER.log(log::Logger::LogLevel::ERROR, "Fatal CANopen error");
+}
+
+extern "C" void COIfCanReceive(CO_IF_FRM *frm) { }
+
+extern "C" int16_t COLssStore(uint32_t baudrate, uint8_t nodeId) { return 0; }
+
+extern "C" int16_t COLssLoad(uint32_t *baudrate, uint8_t *nodeId) { return 0; }
+
+extern "C" void CONmtModeChange(CO_NMT *nmt, CO_MODE mode) { }
+
+extern "C" void CONmtHbConsEvent(CO_NMT *nmt, uint8_t nodeId) { }
+
+extern "C" void CONmtHbConsChange(CO_NMT *nmt, uint8_t nodeId, CO_MODE mode) { }
+
+extern "C" int16_t COParaDefault(CO_PARA *pg) { return 0; }
+
+extern "C" void COPdoTransmit(CO_IF_FRM *frm) { }
+
+extern "C" int16_t COPdoReceive(CO_IF_FRM *frm) { return 0; }
+
+extern "C" void COPdoSyncUpdate(CO_RPDO *pdo) { }
+
+extern "C" void COTmrLock(void) { }
+
+extern "C" void COTmrUnlock(void) { }
 
 int main() {
     // Initialize system
     IO::init();
 
-    // Setup UART
-    IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);
+    // Queue that will store CANopen messages
+    EVT::core::types::FixedQueue<CANOPEN_QUEUE_SIZE, IO::CANMessage> canOpenQueue;
 
-    // String to store user input
-    char buf[100];
+    // Initialize CAN, add an IRQ that will populate the above queue
+    IO::CAN& can = IO::getCAN<IO::Pin::PA_12, IO::Pin::PA_11>();
+    can.addIRQHandler(canInterruptHandler, reinterpret_cast<void*>(&canOpenQueue));
+
+    // Initialize the timer
+    DEV::Timerf302x8 timer(TIM2, 100);
+
+    // Set up Logger
+    IO::UART& uart = IO::getUART<IO::Pin::UART_TX, IO::Pin::UART_RX>(9600);
+    log::LOGGER.setUART(&uart);
+    log::LOGGER.setLogLevel(log::Logger::LogLevel::INFO);
+
+    TMS::TMS tms;
+
+    // Reserved memory for CANopen stack usage
+    uint8_t sdoBuffer[1][CO_SDO_BUF_BYTE];
+    CO_TMR_MEM appTmrMem[4];
+
+    // Initialize the CANopen drivers
+    CO_IF_DRV canStackDriver;
+
+    CO_IF_CAN_DRV canDriver;
+    CO_IF_TIMER_DRV timerDriver;
+    CO_IF_NVM_DRV nvmDriver;
+
+    IO::getCANopenCANDriver(&can, &canOpenQueue, &canDriver);
+    IO::getCANopenTimerDriver(&timer, &timerDriver);
+    IO::getCANopenNVMDriver(&nvmDriver);
+
+    canStackDriver.Can = &canDriver;
+    canStackDriver.Timer = &timerDriver;
+    canStackDriver.Nvm = &nvmDriver;
+
+    CO_NODE_SPEC canSpec = {
+        .NodeId = TMS::TMS::NODE_ID,
+        .Baudrate = IO::CAN::DEFAULT_BAUD,
+        .Dict = tms.getObjectDictionary(),
+        .DictLen = tms.getObjectDictionarySize(),
+        .EmcyCode = nullptr,
+        .TmrMem = appTmrMem,
+        .TmrNum = 16,
+        .TmrFreq = 100,
+        .Drv = &canStackDriver,
+        .SdoBuf = reinterpret_cast<uint8_t*>(&sdoBuffer[0]),
+    };
+
+    CO_NODE canNode;
+
+    CONodeInit(&canNode, &canSpec);
+    CONodeStart(&canNode);
+    //TODO: Set up network messaging
 
     while (1) {
-        // Read user input
-        uart.printf("Enter message: ");
-        uart.gets(buf, 100);
-        uart.printf("\n\recho: %s\n\r", buf);
+        // Process incoming CAN messages
+        CONodeProcess(&canNode);
+        // Update the state of timer based events
+        COTmrService(&canNode.Tmr);
+        // Handle executing timer events that have elapsed
+        COTmrProcess(&canNode.Tmr);
+        // Wait for new data to come in
+        time::wait(10);
     }
 }

--- a/targets/TMS/main.cpp
+++ b/targets/TMS/main.cpp
@@ -3,7 +3,6 @@
  * basic echo functionality where the uart will write back whatever the user
  * enters.
  */
-#include <EVT/dev/platform/f3xx/f302x8/Timerf302x8.hpp>
 #include <EVT/io/CANopen.hpp>
 #include <EVT/io/UART.hpp>
 #include <EVT/io/manager.hpp>
@@ -12,6 +11,7 @@
 #include <EVT/utils/log.hpp>
 #include <EVT/utils/types/FixedQueue.hpp>
 
+#include <EVT/dev/platform/f3xx/f302x8/Timerf302x8.hpp>
 #include <TMS/TMS.hpp>
 
 namespace IO = EVT::core::IO;


### PR DESCRIPTION
Set up CAN messaging for the TMS
Heavily based on the CANopen example in EVT Core
Implements NMT messaging as a slave as defined in the CANopen standard

NOTE: Currently untested. Needs to be tested after the new CAN testing system is set up.