### PR TITLE
Tms/akhil/heat pump rework

### DIFF
--- a/include/TMS/dev/HeatPump.hpp
+++ b/include/TMS/dev/HeatPump.hpp
@@ -3,9 +3,6 @@
 
 #include <EVT/io/PWM.hpp>
 
-// Maximum period is 20000 (20 ms), so this value is set as close to the max as can be safe, which
-// allows the minimum of the init speed to be as low as possible
-
 // We want to maximize frequency, the max frequency can be 950 HZ.
 // To achieve this period must be T = 1/950 seconds which is (~ 1053 microseconds or 1.053 ms)
 #define PERIOD 1053

--- a/include/TMS/dev/HeatPump.hpp
+++ b/include/TMS/dev/HeatPump.hpp
@@ -2,6 +2,7 @@
 #define TMS_INCLUDE_TMS_DEV_HEATPUMP_HPP
 
 #include <EVT/io/PWM.hpp>
+#include <EVT/utils/time.hpp>
 
 // We want to maximize frequency, the max frequency can be 950 HZ.
 // NOTE: Datasheet says 1000 Hz but I have put it down 50 Hz for some errors that can occur will running at max
@@ -12,6 +13,8 @@
 #define SPEED_TO_DUTY_CYCLE(speed) ((speed * 72 / 100) + 13)//d = (85 - 13)(s / 100) + 13
 
 namespace IO = EVT::core::IO;
+namespace time = EVT::core::time;
+
 
 namespace TMS {
 
@@ -43,13 +46,6 @@ public:
 private:
     /** PWM instance to control the pump */
     IO::PWM& pwm;
-    /**
-     * Whether or not the pump is initialized
-     *
-     * Necessary because the speed of the pump needs to be set differently depending on whether it
-     * has been initialized
-     */
-    bool isInitialized;
 };
 
 }// namespace TMS

--- a/include/TMS/dev/HeatPump.hpp
+++ b/include/TMS/dev/HeatPump.hpp
@@ -15,7 +15,6 @@
 namespace IO = EVT::core::IO;
 namespace time = EVT::core::time;
 
-
 namespace TMS {
 
 /**

--- a/include/TMS/dev/HeatPump.hpp
+++ b/include/TMS/dev/HeatPump.hpp
@@ -4,6 +4,7 @@
 #include <EVT/io/PWM.hpp>
 
 // We want to maximize frequency, the max frequency can be 950 HZ.
+// NOTE: Datasheet says 1000 Hz but I have put it down 50 Hz for some errors that can occur will running at max
 // To achieve this period must be T = 1/950 seconds which is (~ 1053 microseconds or 1.053 ms)
 #define PERIOD 1053
 #define MAX_SPEED 100

--- a/include/TMS/dev/HeatPump.hpp
+++ b/include/TMS/dev/HeatPump.hpp
@@ -8,7 +8,7 @@
 #define PERIOD 1053
 #define MAX_SPEED 100
 #define STOP_DUTY_CYCLE 10
-#define SPEED_TO_DUTY_CYCLE(speed) ((speed * 72 / 100) + 13) //d = (85 - 13)(s / 100) + 13
+#define SPEED_TO_DUTY_CYCLE(speed) ((speed * 72 / 100) + 13)//d = (85 - 13)(s / 100) + 13
 
 namespace IO = EVT::core::IO;
 

--- a/include/TMS/dev/HeatPump.hpp
+++ b/include/TMS/dev/HeatPump.hpp
@@ -3,15 +3,15 @@
 
 #include <EVT/io/PWM.hpp>
 
-// Maximum period is 200000 (2 s), so this value is set as close to the max as can be safe, which
+// Maximum period is 20000 (20 ms), so this value is set as close to the max as can be safe, which
 // allows the minimum of the init speed to be as low as possible
-#define PERIOD 19500
-// Value decided by the duty cycle and period to ensure the pump awakens with the appropriate high
-// signal of >= 3000 (3 ms)
-#define MIN_INIT_SPEED 7// d = t / P = 3500 / 19500 * 100 = 17.9; s = (d - 13) / .72 = 6.87 ~ 7
+
+// We want to maximize frequency, the max frequency can be 950 HZ.
+// To achieve this period must be T = 1/950 seconds which is (~ 1053 microseconds or 1.053 ms)
+#define PERIOD 1053
 #define MAX_SPEED 100
 #define STOP_DUTY_CYCLE 10
-#define SPEED_TO_DUTY_CYCLE(speed) ((speed * 72 / 100) + 13)//d = (85 - 13)(s / 100) + 13
+#define SPEED_TO_DUTY_CYCLE(speed) ((speed * 72 / 100) + 13) //d = (85 - 13)(s / 100) + 13
 
 namespace IO = EVT::core::IO;
 

--- a/src/TMS/dev/HeatPump.cpp
+++ b/src/TMS/dev/HeatPump.cpp
@@ -1,7 +1,4 @@
-#include <EVT/utils/time.hpp>
 #include <TMS/dev/HeatPump.hpp>
-
-namespace time = EVT::core::time;
 
 namespace TMS {
 
@@ -21,12 +18,10 @@ void HeatPump::setSpeed(uint16_t speed) {
     }
 
     pwm.setDutyCycle(SPEED_TO_DUTY_CYCLE(speed));
-    isInitialized = true;
 }
 
 void HeatPump::stop() {
     pwm.setDutyCycle(STOP_DUTY_CYCLE);
-    isInitialized = false;
 }
 
 }// namespace TMS

--- a/src/TMS/dev/HeatPump.cpp
+++ b/src/TMS/dev/HeatPump.cpp
@@ -1,8 +1,14 @@
 #include <TMS/dev/HeatPump.hpp>
+#include <EVT/utils/time.hpp>
+
+namespace time = EVT::core::time;
+
 
 namespace TMS {
 
 HeatPump::HeatPump(IO::PWM& pwm) : pwm(pwm) {
+    this->pwm.setDutyCycle(100); // setting the duty cycle to 100% to initially start the pump
+    time::wait(3); // turning on the pump for 3 milliseconds (must do according to data sheet)
     this->pwm.setPeriod(PERIOD);
     stop();
 }
@@ -13,9 +19,6 @@ void HeatPump::setSpeed(uint16_t speed) {
     } else if (speed == 0) {
         stop();
         return;
-    } else if (!isInitialized && speed < MIN_INIT_SPEED) {
-        // Ensures the pump initializes properly
-        speed = MIN_INIT_SPEED;
     }
 
     pwm.setDutyCycle(SPEED_TO_DUTY_CYCLE(speed));

--- a/src/TMS/dev/HeatPump.cpp
+++ b/src/TMS/dev/HeatPump.cpp
@@ -1,14 +1,13 @@
-#include <TMS/dev/HeatPump.hpp>
 #include <EVT/utils/time.hpp>
+#include <TMS/dev/HeatPump.hpp>
 
 namespace time = EVT::core::time;
-
 
 namespace TMS {
 
 HeatPump::HeatPump(IO::PWM& pwm) : pwm(pwm) {
-    this->pwm.setDutyCycle(100); // setting the duty cycle to 100% to initially start the pump
-    time::wait(3); // turning on the pump for 3 milliseconds (must do according to data sheet)
+    this->pwm.setDutyCycle(100);// setting the duty cycle to 100% to initially start the pump
+    time::wait(3);              // turning on the pump for 3 milliseconds (must do according to data sheet)
     this->pwm.setPeriod(PERIOD);
     stop();
 }


### PR DESCRIPTION
The period was changed to max the frequency. The math is explained within the code. TLDR max frequency can be 950 Hz meaning the period must be 1053 microseconds. Also rewrote the start up pump code. It sets the duty cycle to 100% for 3 ms and then shuts it off.